### PR TITLE
Add `new()` methods to adapters

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -91,7 +91,7 @@ dependencies = [
 
 [[package]]
 name = "io-adapters"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "supercilex-tests",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "io-adapters"
-version = "0.3.0"
+version = "0.3.1"
 authors = ["Alex Saveau <saveau.alexandre@gmail.com>"]
 edition = "2021"
 rust-version = "1.65"

--- a/src/adapters/fmt_write.rs
+++ b/src/adapters/fmt_write.rs
@@ -30,6 +30,12 @@ pub struct FmtToIo<W> {
     pub error: Option<io::Error>,
 }
 
+impl<W: io::Write> FmtToIo<W> {
+    pub fn new(inner: W) -> Self {
+        Self { inner, error: None }
+    }
+}
+
 impl<W: io::Write> fmt::Write for FmtToIo<W> {
     fn write_str(&mut self, s: &str) -> fmt::Result {
         match self.inner.write_all(s.as_bytes()) {

--- a/src/adapters/hasher.rs
+++ b/src/adapters/hasher.rs
@@ -20,6 +20,12 @@ use crate::WriteExtension;
 #[derive(Copy, Clone, Debug)]
 pub struct IoToHasher<H>(H);
 
+impl<H: Hasher> IoToHasher<H> {
+    pub fn new(inner: H) -> Self {
+        Self(inner)
+    }
+}
+
 impl<H: Hasher> io::Write for IoToHasher<&mut H> {
     fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
         self.0.write(buf);


### PR DESCRIPTION
A soft solution for [this issue](https://github.com/SUPERCILEX/io-adapters/issues/2#issue-2568685885)